### PR TITLE
Remove invalid argument

### DIFF
--- a/R/wcep_core.R
+++ b/R/wcep_core.R
@@ -40,7 +40,7 @@
               colnames(ew_h) <- c("c1", "event")
               ne_h <- setdiff(ew_h[, 2], ew[, 1])
               ew_h0<- droplevels(ew_h[-which(ew_h$event==ne_h),],exclude=ne_h)
-              ew_h1 <- left_join(ew_h0, ew1, by="event", stringsAsFactors=FALSE)[, c(1, 3)]
+              ew_h1 <- left_join(ew_h0, ew1, by="event")[, c(1, 3)]
               xx <- xx[,-which(colnames(xx) %in% setdiff(colnames(xx), ew_h1[,1]))]
               n <- length(ptid_h)
               lifemat <- matrix(1, nrow = n, ncol = maxtime+1)


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`left_join()` now checks for invalid arguments passed through `...` to catch typos. You passed `stringsAsFactors` through, but that isn't an actual argument to `left_join()`.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!